### PR TITLE
Fix admin dashboard route

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -180,7 +180,7 @@ export default defineComponent({
       {
         title: 'Dashboard',
         icon: 'dashboard',
-        to: '/dashboard',
+        to: { name: 'admin-dashboard' },
         adminOnly: true,
       },
       {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -47,13 +47,8 @@ const routes = [
         meta: { requiresAdmin: true },
       },
       {
-        path: 'admin-dashboard',
-        name: 'admin-dashboard',
-        component: () => import('pages/AdminDashboard.vue'),
-        meta: { requiresAdmin: true },
-      },
-      {
         path: '/dashboard',
+        name: 'admin-dashboard',
         component: () => import('pages/AdminDashboard.vue'),
         meta: { requiresAdmin: true },
       },


### PR DESCRIPTION
## Summary
- remove duplicate admin dashboard route definition
- name remaining `/dashboard` route `admin-dashboard`
- link to dashboard via the named route

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841acb997248326b8c7463eafd3950a