### PR TITLE
Update bookings refresh

### DIFF
--- a/src/pages/AdminDashboard.vue
+++ b/src/pages/AdminDashboard.vue
@@ -911,6 +911,7 @@ export default {
 
         // Ricarica i dati dopo l'eliminazione
         await fetchGameBookings(selectedDate.value);
+        await fetchDailyBookings();
         await fetchCalendarData();
         deleteConfirmDialog.value = false;
       } catch (error) {
@@ -962,6 +963,8 @@ export default {
 
         // Ricarica i dati dopo l'aggiornamento
         await fetchGameBookings(selectedDate.value);
+        await fetchDailyBookings();
+        await fetchCalendarData();
         editBookingDialog.value = false;
       } catch (error) {
         console.error('Errore durante l\'aggiornamento:', error);


### PR DESCRIPTION
## Summary
- refresh daily bookings after deleting a booking
- refresh daily bookings and calendar after saving booking edits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841acca2054832690148cffa777d8d8