### PR TITLE
Fix fetchGameBookings null data handling

### DIFF
--- a/src/pages/AdminDashboard.vue
+++ b/src/pages/AdminDashboard.vue
@@ -773,14 +773,15 @@ export default {
           .gte('data_inizio', startOfDay)
           .lte('data_inizio', endOfDay)
 
-        totalPeopleForSelectedDate.value = data.reduce(
+        const rows = data || []
+        totalPeopleForSelectedDate.value = rows.reduce(
           (acc, booking) => acc + booking.numero_persone,
           0,
         );
 
         const gameBookings = {};
 
-        for (const booking of data) {
+        for (const booking of rows) {
           const gameId = booking.gioco_id;
           if (!gameBookings[gameId]) {
             gameBookings[gameId] = {

--- a/src/pages/AdminDashboard.vue
+++ b/src/pages/AdminDashboard.vue
@@ -271,7 +271,7 @@
                                 round
                                 dense
                                 icon="more_vert"
-                                @click.stop="showBookingActions(booking)"
+                                @click.stop="showBookingActions()"
                               >
                                 <q-menu>
                                   <q-list style="min-width: 100px">
@@ -673,8 +673,6 @@ export default {
         const firstDay = new Date(year, month, 1)
         const lastDay = new Date(year, month + 1, 0)
 
-        const startDate = formatDateForDB(firstDay)
-        const endDate = formatDateForDB(lastDay)
 
         // Query con range di date più ampio per includere giorni prima e dopo il mese corrente
         const prevMonth = new Date(year, month - 1, 1)
@@ -704,6 +702,7 @@ export default {
         calendarData.value = bookingsByDate
 
       } catch (error) {
+        console.error('Errore durante il caricamento dei dati del calendario:', error)
         $q.notify({
           color: 'negative',
           message: 'Si è verificato un errore durante il caricamento dei dati del calendario.',
@@ -740,6 +739,7 @@ export default {
         calendarData.value = bookingsByDate;
 
       } catch (error) {
+        console.error('Errore durante il caricamento dei dati giornalieri:', error)
         $q.notify({
           color: 'negative',
           message: 'Si è verificato un errore durante il caricamento dei dati.',
@@ -881,7 +881,7 @@ export default {
       editBookingDialog.value = true;
     }
 
-    const showBookingActions = (booking) => {
+    const showBookingActions = () => {
       // Questa funzione gestisce l'apertura del menu contestuale
       // Non serve implementare ulteriore logica perché il menu è gestito da q-menu
     }


### PR DESCRIPTION
## Summary
- default rows to an empty array in `fetchGameBookings`
- iterate over `rows` when calculating stats

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841acd1b62883269dda097c6088acd5